### PR TITLE
simulation step cause program to crash

### DIFF
--- a/bot/mcts.py
+++ b/bot/mcts.py
@@ -109,10 +109,16 @@ def _traversal(node: MonteCarloNode, kill_signal: list[bool]) -> MonteCarloNode:
 
 def _simulation(node: MonteCarloNode, kill_signal: list[bool]) -> PlayerCharacter | Literal['T']:
     """Simulation state in Monte Carlo Tree Search. Playout is selected randomly"""
-    state = rand.choice(node.playouts())
-    while not state.game_over and (not kill_signal[0]):
-        state = rand.choice(state.expand_state())
-    return 'T' if (winner := get_winner(state._board_state)) is None else winner
+    # if not node.is_terminal:
+    #     state = rand.choice(node.playouts())
+    #     while not state.game_over and (not kill_signal[0]):
+    #         state = rand.choice(state.expand_state())
+    # else: state = node._state
+
+    while not node.is_terminal and (not kill_signal[0]):
+        node = rand.choice(list(node.children))
+
+    return 'T' if (winner := get_winner(node._state._board_state)) is None else winner
 
 def _backpropogate(node: MonteCarloNode, result: PlayerCharacter | Literal['T'], kill_signal: list[bool]) -> None:
     while node and (not kill_signal[0]):

--- a/bot/mcts.py
+++ b/bot/mcts.py
@@ -109,12 +109,6 @@ def _traversal(node: MonteCarloNode, kill_signal: list[bool]) -> MonteCarloNode:
 
 def _simulation(node: MonteCarloNode, kill_signal: list[bool]) -> PlayerCharacter | Literal['T']:
     """Simulation state in Monte Carlo Tree Search. Playout is selected randomly"""
-    # if not node.is_terminal:
-    #     state = rand.choice(node.playouts())
-    #     while not state.game_over and (not kill_signal[0]):
-    #         state = rand.choice(state.expand_state())
-    # else: state = node._state
-
     while not node.is_terminal and (not kill_signal[0]):
         node = rand.choice(list(node.children))
 


### PR DESCRIPTION
the simulation step can cause the program to crash sometimes when the chosen leaf node is a terminal node.

To fix this, the terminal condition is checked before doing playout